### PR TITLE
Adds the stacktrace to the failure scenario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>org.codice</groupId>
     <artifactId>codice-itest-api</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/codice/itest/api/TestResultFactory.java
+++ b/src/main/java/org/codice/itest/api/TestResultFactory.java
@@ -27,11 +27,11 @@ public interface TestResultFactory {
 
     /**
      * @param testName - the name of the test that failed.
-     * @param exceptionMessage - a description of the failure.
+     * @param throwable - the exception or error that was raised.
      * @param startTime - the start time of the test
      * @return an appropriate TestResult object.
      */
-    TestResult fail(String testName, String exceptionMessage, Instant startTime, Instant endTime);
+    TestResult fail(String testName, Throwable throwable, Instant startTime, Instant endTime);
 
     /**
      * @param testName - the name of the test that failed.


### PR DESCRIPTION
This allows clients to extract useful information from the stack trace in the case of a test failure.